### PR TITLE
feat(auth): integrate GitHub authentication

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "passport": "^0.7.0",
+        "passport-github2": "^0.1.12",
         "passport-local": "^1.0.0"
       },
       "devDependencies": {
@@ -30,6 +31,7 @@
         "@types/jsonwebtoken": "^9.0.7",
         "@types/multer": "^1.4.12",
         "@types/node": "^22.9.0",
+        "@types/passport-github2": "^1.2.9",
         "@types/passport-local": "^1.0.38",
         "prisma": "^5.22.0",
         "tsx": "^4.19.2",
@@ -670,6 +672,16 @@
         "undici-types": "~6.19.8"
       }
     },
+    "node_modules/@types/oauth": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.6.tgz",
+      "integrity": "sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/passport": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
@@ -678,6 +690,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-github2": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@types/passport-github2/-/passport-github2-1.2.9.tgz",
+      "integrity": "sha512-/nMfiPK2E6GKttwBzwj0Wjaot8eHrM57hnWxu52o6becr5/kXlH/4yE2v2rh234WGvSgEEzIII02Nc5oC5xEHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
       }
     },
     "node_modules/@types/passport-local": {
@@ -690,6 +714,18 @@
         "@types/express": "*",
         "@types/passport": "*",
         "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-oauth2": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.17.tgz",
+      "integrity": "sha512-ODiAHvso6JcWJ6ZkHHroVp05EHGhqQN533PtFNBkg8Fy5mERDqsr030AX81M0D69ZcaMvhF92SRckEk2B0HYYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/passport-strategy": {
@@ -857,6 +893,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcrypt": {
       "version": "5.1.1",
@@ -2064,6 +2109,12 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.0.tgz",
+      "integrity": "sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2133,6 +2184,17 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
+    "node_modules/passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
@@ -2142,6 +2204,26 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-strategy": {
@@ -2577,6 +2659,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
     "passport": "^0.7.0",
+    "passport-github2": "^0.1.12",
     "passport-local": "^1.0.0"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@types/jsonwebtoken": "^9.0.7",
     "@types/multer": "^1.4.12",
     "@types/node": "^22.9.0",
+    "@types/passport-github2": "^1.2.9",
     "@types/passport-local": "^1.0.38",
     "prisma": "^5.22.0",
     "tsx": "^4.19.2",

--- a/backend/prisma/migrations/20241205181527_add_github_login_support/migration.sql
+++ b/backend/prisma/migrations/20241205181527_add_github_login_support/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[githubId]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "githubId" TEXT,
+ALTER COLUMN "password" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_githubId_key" ON "users"("githubId");

--- a/backend/prisma/migrations/20241205223912_make_email_optional/migration.sql
+++ b/backend/prisma/migrations/20241205223912_make_email_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "email" DROP NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -9,9 +9,10 @@ datasource db {
 
 model User {
   id             String   @id @default(cuid())
-  email          String   @unique
+  githubId       String?  @unique
+  email          String?  @unique
   username       String   @unique
-  password       String // Hashed password
+  password       String? // Hashed password
   profilePicture String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt

--- a/backend/src/config/passportConfig.ts
+++ b/backend/src/config/passportConfig.ts
@@ -1,6 +1,21 @@
 import passport from "passport";
 import { Strategy as LocalStrategy } from "passport-local";
+import { Strategy as GitHubStrategy } from "passport-github2";
 import { UserModel } from "../models/UserModel";
+
+// Serialize and Deserialize User
+passport.serializeUser((user: Express.User, done) => {
+  done(null, user.id);
+});
+
+passport.deserializeUser(async (id: string, done) => {
+  try {
+    const user = await UserModel.findById(id);
+    done(null, user);
+  } catch (error) {
+    done(error, null);
+  }
+});
 
 passport.use(
   new LocalStrategy(
@@ -10,6 +25,10 @@ passport.use(
         const user = await UserModel.findByEmail(email);
         if (!user) {
           return done(null, false, { message: "User not found" });
+        }
+
+        if (!user.password) {
+          return done(null, false, { message: "User password not found" });
         }
 
         const isPasswordValid = await UserModel.verifyPassword(
@@ -22,6 +41,37 @@ passport.use(
 
         return done(null, user);
       } catch (error) {
+        return done(error);
+      }
+    }
+  )
+);
+
+// GitHub Strategy
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: process.env.GITHUB_CLIENT_ID || "",
+      clientSecret: process.env.GITHUB_CLIENT_SECRET || "",
+      callbackURL: `${process.env.API_URL}/auth/github/callback`,
+    },
+    async (accessToken: any, refreshToken: any, profile: any, done: any) => {
+      const email = profile.emails?.[0]?.value || null; // Fallback to null if email is missing
+      const username = profile.username || `github_user_${profile.id}`; // Fallback username
+      const avatar_url = profile.photos?.[0]?.value || null; // Fallback to null
+
+      try {
+        // Check if user exists in your database
+        let user = await UserModel.findOrCreateGitHubUser({
+          id: profile.id,
+          email,
+          username,
+          avatar_url,
+        });
+
+        return done(null, user);
+      } catch (error) {
+        console.error("GitHub Strategy Error:", error);
         return done(error);
       }
     }

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -124,7 +124,7 @@ export const AuthController = {
 
       req.user = {
         id: user.id,
-        email: user.email,
+        email: user.email || "a",
         username: user.username,
         profilePicture: user.profilePicture,
         createdAt: user.createdAt,
@@ -156,5 +156,22 @@ export const AuthController = {
         createdAt: user.createdAt,
       },
     });
+  },
+
+  githubCallback: (req: Request, res: Response) => {
+    // Generate JWT
+    const user = req.user;
+    if (!user) {
+      res.json({
+        message: "GitHub login failed",
+      });
+      return;
+    }
+
+    const token = jwt.sign({ id: user.id, email: user.email }, JWT_SECRET, {
+      expiresIn: "1h",
+    });
+
+    res.redirect(`http://localhost:5173/auth/callback?token=${token}`);
   },
 };

--- a/backend/src/models/UserModel.ts
+++ b/backend/src/models/UserModel.ts
@@ -130,4 +130,29 @@ export const UserModel = {
       take,
     });
   },
+
+  findOrCreateGitHubUser: async (profile: {
+    id: string;
+    username: string;
+    email: any;
+    avatar_url: string;
+  }) => {
+    const { id, username, email, avatar_url } = profile;
+    let user = await prisma.user.findUnique({
+      where: { githubId: id },
+    });
+
+    if (!user) {
+      user = await prisma.user.create({
+        data: {
+          githubId: id,
+          username,
+          email: email || null, // Handle cases where email is not available
+          profilePicture: avatar_url,
+        },
+      });
+    }
+
+    return user;
+  },
 };

--- a/backend/src/routes/AuthRouter.ts
+++ b/backend/src/routes/AuthRouter.ts
@@ -1,5 +1,6 @@
 import { RequestHandler, Router } from "express";
 import { AuthController } from "../controllers/AuthController";
+import passport from "passport";
 
 const AuthRouter = Router();
 
@@ -9,6 +10,20 @@ AuthRouter.post(
   AuthController.register as RequestHandler
 );
 AuthRouter.post("/login", AuthController.login as RequestHandler);
+
+// GitHub Login
+AuthRouter.get(
+  "/github",
+  passport.authenticate("github", { scope: ["user:email"] })
+);
+
+// GitHub Callback
+AuthRouter.get(
+  "/github/callback",
+  passport.authenticate("github", { session: false }),
+  AuthController.githubCallback
+);
+
 AuthRouter.get(
   "/verify-token",
   AuthController.authenticateJWT as RequestHandler,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,0 +1,7 @@
+import { User as PrismaUser } from "@prisma/client";
+
+declare global {
+  namespace Express {
+    interface User extends PrismaUser {}
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,7 @@ import { PostProvider } from "./contexts/PostContext";
 import TabMenu from "./components/TabMenu";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import AuthCallback from "./pages/AuthCallback";
 
 setupIonicReact();
 
@@ -59,6 +60,11 @@ const App: React.FC = () => {
               <IonApp className="max-w-screen-xl mx-auto p-4">
                 <IonReactRouter>
                   <IonRouterOutlet>
+                    <Route
+                      exact
+                      path="/auth/callback"
+                      component={AuthCallback}
+                    />
                     <Route exact path="/login" component={Login} />
                     <Route exact path="/register" component={Register} />
                     {isAuthenticated ? <TabMenu /> : <Redirect to="/login" />}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -29,3 +29,22 @@ export const verifyToken = async (token: string) => {
   });
   return response.data;
 };
+
+export const loginGitHub = async () => {
+  window.location.href = `${API_BASE_URL}/auth/github`;
+};
+
+export const handleGitHubLoginCallback = () => {
+  console.log("handling github callback");
+  const urlParams = new URLSearchParams(window.location.search);
+  const token = urlParams.get("token");
+  console.log(token);
+
+  if (token) {
+    localStorage.setItem("token", token);
+    console.log("Token saved:", token);
+    window.location.href = "/feed";
+  } else {
+    console.error("GitHub login failed: No token received");
+  }
+};

--- a/frontend/src/components/TabMenu.tsx
+++ b/frontend/src/components/TabMenu.tsx
@@ -15,11 +15,13 @@ import PostDetail from "../pages/PostDetail";
 import UserDetail from "../pages/UserDetail";
 import Users from "../pages/Users";
 import Discover from "../pages/Discover";
+import AuthCallback from "../pages/AuthCallback";
 
 const TabMenu: React.FC = () => {
   return (
     <IonTabs className="bg-background">
       <IonRouterOutlet>
+        <Route exact path="/auth/callback" component={AuthCallback} />
         <Route exact path="/posts/:postId" component={PostDetail} />
         <Route exact path="/users/:userId" component={UserDetail} />
         <Route exact path="/feed" component={Feed} />

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { handleGitHubLoginCallback } from "../api/auth";
+
+const AuthCallback = () => {
+  useEffect(() => {
+    handleGitHubLoginCallback();
+  }, []);
+
+  return <div>Processing login...</div>;
+};
+
+export default AuthCallback;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -7,12 +7,14 @@ import {
   IonItem,
   useIonRouter,
   useIonToast,
+  IonIcon,
 } from "@ionic/react";
 import { Redirect } from "react-router";
-import { login } from "../api/auth";
+import { login, loginGitHub } from "../api/auth";
 import axios from "axios";
 import { AuthContext } from "../contexts/AuthContext";
 import MainHeader from "../components/MainHeader";
+import { logoGithub } from "ionicons/icons";
 
 const Login: React.FC = () => {
   const { user } = useContext(AuthContext);
@@ -88,6 +90,16 @@ const Login: React.FC = () => {
             >
               Login
             </IonButton>
+            <IonButton
+              expand="block"
+              shape="round"
+              onClick={loginGitHub}
+              className="m-4"
+              color="dark"
+            >
+              Login with GitHub <IonIcon icon={logoGithub}></IonIcon>
+            </IonButton>
+
             <IonButton
               expand="block"
               shape="round"


### PR DESCRIPTION
- Added `passport-github2` dependency and its type definitions
- Updated Prisma schema to support GitHub authentication:
  - Added `githubId` field to the `User` model
  - Made `email` and `password` optional fields
- Enhanced `passportConfig.ts`:
  - Added GitHub strategy with `passport-github2`
  - Implemented user serialization and deserialization logic
- Updated `UserModel.ts`:
  - Created `findOrCreateGitHubUser` function to manage GitHub users
- Enhanced `AuthController.ts`:
  - Implemented `githubCallback` for handling GitHub login callback and token generation
- Extended `AuthRouter.ts`:
  - Added routes for GitHub authentication and callback
- Frontend changes:
  - Added `AuthCallback` page for handling GitHub login callback
  - Updated `Login` page to include a GitHub login button
  - Created `loginGitHub` and `handleGitHubLoginCallback` functions in the auth API module
  - Updated `App.tsx` and `TabMenu.tsx` to include routes for `AuthCallback`